### PR TITLE
fix: remove debug logging from JsonMap#transform

### DIFF
--- a/src/JsonMap.ts
+++ b/src/JsonMap.ts
@@ -97,23 +97,17 @@ class JsonMap {
     output: Json,
     path = '',
   ): Promise<Json> {
-    console.debug('#transform params:\n', { node, input, output, path });
-
     // Checks if the current node is an object and has only a '$' key
     if (node instanceof Object && _.size(node) === 1 && '$' in node) {
       // Retrieves the transformations to be applied (can be an array or a single object)
       const transformations = _.castArray(
         node.$ as JsonMapTransform | JsonMapTransform[],
       );
-      console.debug('transformations:\n', transformations);
-
       // Array to store the results of the transformations
       const results: Json = [];
 
       // Iterates over each transformation
       for (const transformation of transformations) {
-        console.debug('processing transformation:\n', transformation);
-
         // Resolves the object path for the transformation
         const { obj: methodObj, path: methodPath } = this.#resolvePath(
           transformation.method,
@@ -136,8 +130,6 @@ class JsonMap {
           },
         );
 
-        console.debug('resolved transformation params:\n', params);
-
         // Calls the specified method on the resolved object with the resolved parameters
         const result = (await _.invoke(
           methodObj,
@@ -145,16 +137,12 @@ class JsonMap {
           ...params,
         )) as Json;
 
-        console.debug('transformation result:\n', result);
-
         // Stores the result of the transformation
         results.unshift(result);
       }
 
       // Sets the output at the specified path to the last result of the transformations & returns.
       _.set(output as object, path, results[0]);
-
-      console.debug('updated output:\n', output);
 
       return results[0];
     }


### PR DESCRIPTION
Removes six console.debug calls from the #transform method that were logging transformation params, results, and output on every invocation. These produce excessive noise when used by jeeves-watcher with many inference rules.